### PR TITLE
Use re.Pattern due to removal of re._pattern_type

### DIFF
--- a/logicode.py
+++ b/logicode.py
@@ -12,7 +12,10 @@ if not hasattr(__builtins__, "raw_input"):
 if not hasattr(__builtins__, "basestring"):
     basestring = str
 
-regex = re._pattern_type
+if hasattr(re, "Pattern"):
+    regex = re.Pattern
+else:
+    regex = re._pattern_type
 
 rWhitespace = re.compile(r"[ \t]+", re.M)
 rCommandSeparator = re.compile(r"[\r\n;]+", re.M)


### PR DESCRIPTION
Hello.

Python 3.7 removed `re._pattern_type` ( see python/cpython#1646 ) and added `re.Pattern` type instead.

To support python 3.7 (or later), I rewrited to use re.Pattern and added rollback.

Thanks!